### PR TITLE
Make package publishable and installable

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,61 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+
+# node.js
+#
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# BUCK
+buck-out/
+\.buckd/
+*.keystore
+!debug.keystore
+
+# Bundle artifacts
+*.jsbundle
+
+# CocoaPods
+/ios/Pods/
+
+# Expo
+.expo/
+web-build/
+dist/
+
+#vscode
+.vscode
+
+ios
+android

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sdk-react-native",
   "version": "1.0.0",
+  "license": "MIT",
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client",
@@ -13,7 +14,8 @@
     "lint-fix": "prettier --write .",
     "prepare": "husky install"
   },
-  "dependencies": {
+  "dependencies": {},
+  "peerDependencies": {
     "expo": "~45.0.0",
     "expo-font": "~10.1.0",
     "expo-linear-gradient": "~11.3.0",
@@ -27,6 +29,17 @@
     "rn-sliding-up-panel": "^2.4.5"
   },
   "devDependencies": {
+    "expo": "~45.0.0",
+    "expo-font": "~10.1.0",
+    "expo-linear-gradient": "~11.3.0",
+    "expo-splash-screen": "~0.15.1",
+    "expo-status-bar": "~1.3.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-native": "0.68.2",
+    "react-native-svg": "12.3.0",
+    "react-native-web": "0.17.7",
+    "rn-sliding-up-panel": "^2.4.5",
     "@babel/core": "^7.12.9",
     "@storybook/addon-actions": "^5.3",
     "@storybook/addon-knobs": "^5.3",
@@ -40,6 +53,5 @@
     "typescript": "~4.3.5",
     "husky": "^7.0.4",
     "prettier": "^2.6.2"
-  },
-  "private": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5798,9 +5798,9 @@ find-yarn-workspace-root@~2.0.0:
     micromatch "^4.0.2"
 
 flow-parser@0.*:
-  version "0.181.1"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.181.1.tgz#bb6bd5afbc8399a690570dd47083d27dabe31c3e"
-  integrity sha512-+Mx87/GkmF5+FHk8IXc5WppD/oC4wB+05MuIv7qmIMgThND3RhOBGl7Npyc2L7NLVenme00ZlwEKVieiMz4bqA==
+  version "0.181.2"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.181.2.tgz#2c98ae959f59d2895dce80a19513893f6783eb92"
+  integrity sha512-+QzNZEmhYNF9SHrKI8M2lzT07UGkJW6Zoeg7wP+aGkFxh0Mh/wx8eyS/lcwY9bd3B4azS6K50ZjyIjzMWpowGg==
 
 flow-parser@^0.121.0:
   version "0.121.0"
@@ -10822,9 +10822,9 @@ style-loader@^1.0.0:
     schema-utils "^2.7.0"
 
 sucrase@^3.20.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.22.0.tgz#9fd6d12b93c758a65c3b99cc3e4436274ea79d55"
-  integrity sha512-RZeE0UPxCjf99p4c9Sb27qRbsuZBd7TViR/q1P6TsUPYa/H2LIkaCPpio6F1nQksrynYA78KEBUnpxswZiPYcg==
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.23.0.tgz#2a7fa80a04f055fb2e95d2aead03fec1dba52838"
+  integrity sha512-xgC1xboStzGhCnRywlBf/DLmkC+SkdAKqrNCDsxGrzM0phR5oUxoFKiQNrsc2D8wDdAm03iLbSZqjHDddo3IzQ==
   dependencies:
     commander "^4.0.0"
     glob "7.1.6"


### PR DESCRIPTION
- add .npmignore
- moved dependencies to peerDependencies
- it is now possible to `npm publish` / `npm install`

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>