### PR TITLE
include support to domain field input

### DIFF
--- a/src/PromptRecognized.tsx
+++ b/src/PromptRecognized.tsx
@@ -35,6 +35,7 @@ const Component: React.FC = () => {
           value={username}
           onChangeText={setUsername}
           icon="IconUser"
+          domain
         />
       </ContainerContent>
 

--- a/src/components/FieldWithIcon.tsx
+++ b/src/components/FieldWithIcon.tsx
@@ -27,9 +27,13 @@ type Props = {
   lightTheme?: boolean;
   autoFocus?: boolean;
   style?: StyleProp<ViewStyle>;
+  domain?: boolean;
 };
 const FieldWithIcon: React.FC<Props> = (props: Props) => {
-  const styles = getStyles(!!props.lightTheme);
+  const styles = getStyles(
+    !!props.lightTheme,
+    !!props.domain && props.value?.length > 0
+  );
   const Icon = icons[props.icon];
 
   let borderStyle = undefined;
@@ -43,7 +47,7 @@ const FieldWithIcon: React.FC<Props> = (props: Props) => {
       <View style={[styles.input, borderStyle]}>
         {Icon(props.warning && "#FF2866")}
         <TextInput
-          style={[styles.textInput]}
+          style={styles.textInput}
           value={props.value}
           onChangeText={props.onChangeText}
           secureTextEntry={props.secureTextEntry}
@@ -52,6 +56,9 @@ const FieldWithIcon: React.FC<Props> = (props: Props) => {
           autoCorrect={false}
         />
         {props.warning ? <WarningOutline /> : null}
+        {props.domain && props.value?.length > 0 ? (
+          <Text style={styles.domain}>.snr</Text>
+        ) : null}
       </View>
       {!!props.warning && (
         <Text style={styles.warningText}>{props.warning}</Text>
@@ -60,7 +67,7 @@ const FieldWithIcon: React.FC<Props> = (props: Props) => {
   );
 };
 
-const getStyles = (lightTheme: boolean) =>
+const getStyles = (lightTheme: boolean, domain: boolean) =>
   StyleSheet.create({
     input: {
       flexDirection: "row",
@@ -81,14 +88,17 @@ const getStyles = (lightTheme: boolean) =>
       marginBottom: 8,
     },
     textInput: {
-      flex: 1,
+      flex: domain ? 0 : 1,
       paddingVertical: 12,
       marginLeft: 12,
       fontFamily: "THICCCBOI_Regular",
-      fontStyle: "normal",
       fontSize: 16,
-      lineHeight: 20,
       color: lightTheme ? "#37324A" : "#F6F5FA",
+    },
+    domain: {
+      fontFamily: "THICCCBOI_Regular",
+      fontSize: 16,
+      color: lightTheme ? "#37324A" : "#9693a2",
     },
     warningText: {
       fontFamily: "THICCCBOI_Medium",


### PR DESCRIPTION
include support to domain field input
if you set 'domain' and .snr suffix letter will appear

## Changes

- Include domain parameter
- set style for it
- fix input sizing

## API Updates

### New Features *(required)*

no changes

### Deprecations *(required)*

N/A

### Enhancements *(optional)*

You can easily use an domain input field

## Checklist

- [ ] Unit tests
- [ ] Documentation

![Simulator Screen Shot - iPhone 13 - 2022-07-19 at 17 48 32](https://user-images.githubusercontent.com/7022648/179846128-cbbb63bb-4c56-415c-b80f-194aaba01a54.png)



<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>